### PR TITLE
Always specify packageType in command line (bundle/apk)

### DIFF
--- a/main.go
+++ b/main.go
@@ -526,8 +526,12 @@ func buildIonicCommandArgs(ionicMajorVersion int, configuration string, target s
 		groupArgs[group] = append(groupArgs[group], option)
 	}
 
-	if platform == "android" && isAAB {
-		groupArgs[2] = append(groupArgs[2], "--packageType=bundle")
+	if platform == "android" {
+		if isAAB {
+			groupArgs[2] = append(groupArgs[2], "--packageType=bundle")
+		} else {
+			groupArgs[2] = append(groupArgs[2], "--packageType=apk")
+		}
 	}
 
 	if len(groupArgs[0]) > 0 {

--- a/main_test.go
+++ b/main_test.go
@@ -18,7 +18,7 @@ func Test_buildIonicCommandArgs(t *testing.T) {
 		{name: "NoOptions & NoAAB", args: args{
 			isAAB:   false,
 			options: nil,
-		}, want: []string{"cordova", "build", "--release", "--device", "android", "--buildConfig", "/foo/bar/baz/qux"}},
+		}, want: []string{"cordova", "build", "--release", "--device", "android", "--buildConfig", "/foo/bar/baz/qux", "--", "--", "--packageType=apk"}},
 		{name: "NoOptions & AAB", args: args{
 			isAAB:   true,
 			options: nil,
@@ -30,7 +30,7 @@ func Test_buildIonicCommandArgs(t *testing.T) {
 		{name: "SimpleOptions & NoAAB", args: args{
 			isAAB:   false,
 			options: []string{"foo", "bar"},
-		}, want: []string{"cordova", "build", "--release", "--device", "android", "--buildConfig", "/foo/bar/baz/qux", "foo", "bar"}},
+		}, want: []string{"cordova", "build", "--release", "--device", "android", "--buildConfig", "/foo/bar/baz/qux", "foo", "bar", "--", "--", "--packageType=apk"}},
 		{name: "SimpleOptions + Platform & AAB", args: args{
 			isAAB:   true,
 			options: []string{"foo", "bar", "--", "--", "--baz=qux"},


### PR DESCRIPTION
### Checklist

- [x] I've read and accepted the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- Requires _MINOR_ [version update](https://semver.org/)

### Context

Cordova-android 10 made bundle package type the default : https://github.com/apache/cordova-android/pull/1268
So using this step's option `android_app_type: apk` with cordova-android@10 still builds an aab (and make the step failed because apk result is not found)


### Changes

Always specifying `---packageType` has no downsides and make it compatible with all cordova-android versions.

