### PR TITLE
Set Java to version 8 for e2e tests

### DIFF
--- a/e2e/bitrise.yml
+++ b/e2e/bitrise.yml
@@ -129,6 +129,9 @@ workflows:
       - nvm@1:
           inputs:
             - node_version: '12'
+      - set-java-version:
+          inputs:
+          - set_java_version: 8
 
   _install_dependencies_with_npm:
     steps:


### PR DESCRIPTION
### Checklist
- [x] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [x] `step.yml` and `README.md` is updated with the changes (if needed)

### Changes

- Set Java to version 8 for e2e tests
